### PR TITLE
add start task, aligning with readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ help:
 install: package.json ## install dependencies
 	echo "Full install..."
 	yarn
+	
+start: package.json
+		@yarn start
 
 run: ## run the site locally
 	@yarn dev


### PR DESCRIPTION
outputs like this:
```
➜  retro-admin git:(main) ✗ make start
yarn run v1.22.17
warning package.json: No license field
$ vite

  vite v2.6.14 dev server running at:

  > Local: http://localhost:8080/
  > Network: use `--host` to expose

  ready in 247ms.
```